### PR TITLE
CMS/TMS 即将更新 New Age 改版的改动

### DIFF
--- a/src/i18n/zh-cn/index.json
+++ b/src/i18n/zh-cn/index.json
@@ -85,14 +85,14 @@
   "burning_cernium": "燃烧的塞尔提乌",
   "hotel_arcs": "亚克斯旅馆",
   "odium": "奥迪乌姆",
-  "shangri_la": "香格里拉(暂译)",
-  "arteria": "阿尔泰利亚(暂译)",
-  "carcion": "卡尔西温(暂译)",
+  "shangri_la": "桃源境",
+  "arteria": "阿尔特里亚",
+  "carcion": "卡西翁",
 
   "vanishingjourney": "消亡旅途",
   "chuchu": "啾啾村",
   "hotelarcs": "亚克斯旅馆",
-  "shangrila": "香格里拉(暂译)",
+  "shangrila": "桃源境",
 
   "is_estimated": "(预估值)",
 


### PR DESCRIPTION
CMS已经确定275-285地图的名称了，TMS也需要一并修正。
此外，由于所有伺服都已经进入New Age改版，可以考虑删除以往的旧版本了。